### PR TITLE
Fix Streamlit Cloud deployment blockers: Python 3.11 syntax error and unreadable database

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,52 @@ The `app.py` provides:
 - **Comparison Tools**: Compare multiple names side by side
 - **Interactive Charts**: Built with Plotly for rich visualizations
 
+## Deployment
+
+The app reads every page from a SQLite database. Before deploying, make sure that
+database is actually reachable in the deployed environment.
+
+### The database is not in the Git checkout
+
+`data/names.db` is tracked with Git LFS (see `.gitattributes`), and the object is
+roughly 1.1 GB. **Streamlit Community Cloud clones repositories without resolving Git
+LFS objects**, so the deployed checkout contains only a 135-byte pointer file rather
+than the database. Reading it raises `DatabaseError: file is not a database`.
+
+The app now detects this at startup and stops with an explanatory message instead of
+failing deep inside a query.
+
+### Supplying the database
+
+Point the app at a copy it can actually read, using either Streamlit secrets
+(`.streamlit/secrets.toml`) or environment variables:
+
+| Setting | Purpose | Default |
+| --- | --- | --- |
+| `NAMES_DB_PATH` | Path to a local `names.db` | `data/names.db` |
+| `NAMES_DB_REPO` | Hugging Face repo to download the database from when no local copy is usable | unset |
+| `NAMES_DB_FILE` | Filename to fetch from that repo | `names.db` |
+| `NAMES_DB_REPO_TYPE` | `dataset` or `model` | `dataset` |
+| `HF_TOKEN` | Token for a private Hugging Face repo | unset |
+| `GROQ_API_KEY` | Required for the AI Chatbot page | unset |
+
+Example `.streamlit/secrets.toml`:
+
+```toml
+NAMES_DB_REPO = "your-username/baby-names"
+NAMES_DB_FILE = "names.db"
+GROQ_API_KEY = "your-key"
+```
+
+The download is cached with `st.cache_resource`, so it runs once per app process.
+
+### A note on database size
+
+Streamlit Community Cloud gives each app a limited amount of disk and memory, and a
+1.1 GB database is likely to exceed it even when downloaded at runtime. The app only
+queries a single `names` table with six columns, so rebuilding a slimmer database
+(dropping unused tables and indexes) is the more durable fix.
+
 ## Data Structure
 
 The processed data includes:

--- a/app.py
+++ b/app.py
@@ -37,10 +37,113 @@ st.set_page_config(
     initial_sidebar_state="expanded"
 )
 
+# --- Baby names database resolution --------------------------------------
+
+DEFAULT_DB_PATH = "data/names.db"
+SQLITE_MAGIC = b"SQLite format 3\x00"
+LFS_POINTER_MAGIC = b"version https://git-lfs.github.com/spec/v1"
+
+
+class DatabaseUnavailableError(RuntimeError):
+    """Raised when names.db cannot be resolved to a readable SQLite database"""
+
+
+def get_config_value(key):
+    """Get a setting from Streamlit secrets, falling back to environment variables"""
+    value = None
+    try:
+        # Try Streamlit secrets first
+        value = st.secrets.get(key)
+    except Exception:
+        pass
+
+    if not value:
+        value = os.environ.get(key)
+
+    return value
+
+
+def describe_db_problem(path):
+    """Describe why the file at path is not a usable database, or return None if it is"""
+    if not os.path.exists(path):
+        return f"No file was found at `{path}`."
+
+    with open(path, "rb") as handle:
+        head = handle.read(256)
+
+    if head.startswith(LFS_POINTER_MAGIC):
+        match = re.search(rb"^size (\d+)$", head, flags=re.MULTILINE)
+        expected = f" The real object is {int(match.group(1)) / 1e9:.2f} GB." if match else ""
+        return (
+            f"`{path}` is a Git LFS pointer of {os.path.getsize(path)} bytes rather than the "
+            f"database itself.{expected} Streamlit Community Cloud checks out repositories "
+            "without resolving Git LFS objects, so only the pointer text is present."
+        )
+
+    if not head.startswith(SQLITE_MAGIC):
+        return f"`{path}` is not a SQLite database - its file header is unrecognized."
+
+    return None
+
+
+@st.cache_resource(show_spinner="Loading the baby names database...")
+def resolve_database_path():
+    """Find a readable copy of names.db, downloading it when a remote source is configured"""
+    local_path = get_config_value("NAMES_DB_PATH") or DEFAULT_DB_PATH
+    problem = describe_db_problem(local_path)
+    if problem is None:
+        return local_path
+
+    repo_id = get_config_value("NAMES_DB_REPO")
+    if not repo_id:
+        raise DatabaseUnavailableError(
+            f"{problem}\n\nEither commit a real `{DEFAULT_DB_PATH}` (Git LFS will not work on "
+            "Streamlit Community Cloud), point `NAMES_DB_PATH` at a local copy, or set "
+            "`NAMES_DB_REPO` so the database is downloaded at startup."
+        )
+
+    filename = get_config_value("NAMES_DB_FILE") or "names.db"
+    try:
+        from huggingface_hub import hf_hub_download
+
+        downloaded = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            repo_type=get_config_value("NAMES_DB_REPO_TYPE") or "dataset",
+            token=get_config_value("HF_TOKEN"),
+        )
+    except Exception as e:
+        raise DatabaseUnavailableError(
+            f"{problem}\n\nDownloading `{filename}` from `{repo_id}` failed: {e}"
+        ) from e
+
+    problem = describe_db_problem(downloaded)
+    if problem is not None:
+        raise DatabaseUnavailableError(f"The downloaded database is unusable. {problem}")
+
+    logger.info("Using baby names database downloaded from %s", repo_id)
+    return downloaded
+
+
+def connect_to_database():
+    """Open a connection to the baby names database"""
+    return sqlite3.connect(resolve_database_path())
+
+
+def require_database():
+    """Halt the app with an actionable message when the database cannot be loaded"""
+    try:
+        resolve_database_path()
+    except DatabaseUnavailableError as e:
+        st.error("The baby names database is unavailable, so the app cannot start.")
+        st.markdown(str(e))
+        st.stop()
+
+
 @st.cache_data
 def load_top_names_data(sex, top_n, year):
     """Load and aggregate the baby names data for top names"""
-    conn = sqlite3.connect("data/names.db")
+    conn = connect_to_database()
     df = pd.read_sql_query(f"SELECT * FROM names WHERE sex = '{sex}' AND year = {year} ORDER BY total_count DESC LIMIT {top_n}", conn)
     conn.close()
     return df
@@ -48,7 +151,7 @@ def load_top_names_data(sex, top_n, year):
 @st.cache_data
 def load_name_search_data(name, sex):
     """Load and aggregate the baby names data for name search"""
-    conn = sqlite3.connect("data/names.db")
+    conn = connect_to_database()
     df = pd.read_sql_query(f"SELECT * FROM names WHERE LOWER(name) = LOWER('{name}') AND sex = '{sex}'", conn)
     conn.close()
     return df
@@ -705,7 +808,7 @@ def top_names_page():
         st.stop()
     
     # Top names section
-    st.header(f"Top {top_n} {"Male" if sex == "M" else "Female"} Names")
+    st.header(f"Top {top_n} {'Male' if sex == 'M' else 'Female'} Names")
     
     # Get top names
     top_names = top_names_df[top_names_df['sex'] == sex].head(top_n)
@@ -715,7 +818,7 @@ def top_names_page():
         top_names,
         x='name',
         y='total_count',
-        title=f"Top {top_n} {"Male" if sex == "M" else "Female"} Names by Total Count",
+        title=f"Top {top_n} {'Male' if sex == 'M' else 'Female'} Names by Total Count",
         labels={'total_count': 'Total Count', 'name': 'Name'},
         color='total_count',
         color_continuous_scale='Viridis'
@@ -986,7 +1089,7 @@ def execute_safe_sql(query, max_rows=1000):
             query = query.rstrip() + f" LIMIT {max_rows}"
     
     try:
-        conn = sqlite3.connect("data/names.db")
+        conn = connect_to_database()
         df = pd.read_sql_query(query, conn)
         conn.close()
         
@@ -1286,6 +1389,9 @@ def chatbot_page():
 
 def main():
     """Main function with page navigation"""
+    # Every page reads from the database, so fail fast with a clear message
+    require_database()
+
     # Sidebar navigation
     st.sidebar.title("Navigation")
     page = st.sidebar.radio("Go to", ["🏠 Home", "💬 AI Chatbot", "🔍 Name Search", "👶 Top Names"])


### PR DESCRIPTION
## Context

Investigation started from a reported `zipfile.BadZipFile` traceback in the deployed app.

**That traceback does not come from this repository.** It points at `/mount/src/baby-names/baby_names.py`, and `baby_names.py` has never existed in `baby-names-app` — not in any commit, branch, or ref. This repo's entry point is `app.py`, which contains no `zipfile` code at all; it reads from SQLite. The deployed app is running older code from a separate `baby-names` repo that isn't reachable from here.

For the record, the cause of that error is well evidenced: the old `load_data()` downloaded the SSA zip at runtime and passed the response bytes straight to `zipfile.ZipFile`. `data_pipeline.ipynb` documents exactly why that breaks — *"this website detects automated requests and blocks them"* — so SSA returns an HTML block page and `ZipFile` sees `<!DOCTYPE html` instead of `PK\x03\x04`. That's why the notebook moved to Selenium.

This PR instead fixes the two blockers that stop **this** repo from deploying.

## Blocker 1 — `app.py` does not parse on Python 3.11

Streamlit Cloud runs Python 3.11 (visible in the reported traceback). Two f-strings reused double quotes inside their replacement fields:

```python
st.header(f"Top {top_n} {"Male" if sex == "M" else "Female"} Names")
```

Nested same-type quotes are only valid from Python 3.12 (PEP 701). On 3.11 this is a hard `SyntaxError`, so the app cannot start at all. Switched the inner quotes to single quotes.

## Blocker 2 — the database isn't in the deployed checkout

`data/names.db` is tracked by Git LFS (`.gitattributes`: `*.db filter=lfs`) and the object is **~1.1 GB**. Streamlit Community Cloud clones without resolving LFS objects, so the deployed checkout holds only a 135-byte pointer file. All three `sqlite3.connect("data/names.db")` sites then failed inside `pd.read_sql_query` with an opaque `DatabaseError: file is not a database`.

All three now route through one resolver that:

- detects a Git LFS pointer (or any non-SQLite file) and says so explicitly, including the real object size
- optionally downloads the database from a Hugging Face repo — `huggingface-hub` was already in `requirements.txt` but unused
- allows overriding the local path

`main()` calls `require_database()`, so an unusable database stops the app with an actionable message instead of surfacing a cryptic error mid-page.

### Configuration

Via Streamlit secrets or environment variables, following the existing `get_groq_client` pattern:

| Setting | Purpose | Default |
| --- | --- | --- |
| `NAMES_DB_PATH` | Path to a local `names.db` | `data/names.db` |
| `NAMES_DB_REPO` | Hugging Face repo to download from when no local copy is usable | unset |
| `NAMES_DB_FILE` | Filename to fetch from that repo | `names.db` |
| `NAMES_DB_REPO_TYPE` | `dataset` or `model` | `dataset` |
| `HF_TOKEN` | Token for a private repo | unset |

## Testing

- `app.py` compiles under Python 3.11.15 — it did not before this change.
- `describe_db_problem` checked against four fixtures: the real 135-byte LFS pointer (correctly reports the 1.10 GB object), a missing file, a valid SQLite database, and an HTML/garbage file.
- Three scenarios exercised through `streamlit.testing.v1.AppTest`:
  - LFS pointer present → app stops with the diagnostic, no exception raised
  - valid database via `NAMES_DB_PATH` → resolves and proceeds
  - pointer + unreachable `NAMES_DB_REPO` → download failure is caught and wrapped, not crashed

## Note on database size

Streamlit Community Cloud's per-app disk and memory limits make a 1.1 GB database likely to fail even when downloaded at runtime. The app only queries a single `names` table with six columns, so rebuilding a slimmer database is the more durable fix. Flagged in the README rather than attempted here, since it's a data-pipeline change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7H5mBb3rsUD6J2Cfxqbv7)_