### PR TITLE
chore(deps): consolidate second round of Dependabot updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,9 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,13 +36,13 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.6",
+        "@testing-library/user-event": "^14.6.7",
         "@types/node": "^26.4.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
-      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
-    "@testing-library/user-event": "^14.6.6",
+    "@testing-library/user-event": "^14.6.7",
     "@types/node": "^26.4.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,17 +3,17 @@
 # frontend/package.json (npm).
 pandas==3.0.5
 requests==2.34.2
-plotly==6.9.0
+plotly==7.0.0
 matplotlib==3.11.1
 nbformat==5.11.1
 numpy==2.5.2
-huggingface-hub==1.28.0
+huggingface-hub==1.29.0
 hf-xet==1.6.0
 ipykernel==7.3.0
-selenium==4.47.0
-sentence-transformers==6.0.0
+selenium==4.48.0
+sentence-transformers==6.0.1
 faiss-cpu==1.15.0
 scikit-learn==1.9.0
 scipy==1.18.1
-statsmodels==0.14.6
+statsmodels==0.15.0
 xgboost==3.4.1


### PR DESCRIPTION
Consolidates the five Dependabot PRs opened after #26 merged (#27, #28, #29, #30, #31) into one change.

## Why there are new PRs

Two of the five (#27, #28) exist *because* of #26 — that PR added the `pip` ecosystem for the root `requirements.txt`, so Dependabot scanned the notebook pins for the first time and found five updates it had never been able to see before. The other three are the regular weekly/monthly cadence.

## Vulnerability status: still none

Dependabot alerts remain **disabled** on the repository (`GET /repos/dwest1507/baby-names-app/dependabot/alerts` → `403 "Dependabot alerts are disabled for this repository."`). Every one of these five PRs is a routine version update, not a security fix. Direct scans confirm nothing exploitable:

| Scanner | Scope | Result |
| --- | --- | --- |
| `npm audit` | `frontend/package-lock.json` | 0 vulnerabilities |
| `pip-audit` | `backend/uv.lock`, full locked set | No known vulnerabilities |
| `./scripts/security-audit.sh all` | production deps, both stacks | OK |

This is the second PR in a row reporting zero findings, which is the expected result while alerts are off — Dependabot cannot open a security update, so `npm audit` / `pip-audit` in `security.yml` remain the only vulnerability signal. Enabling alerts under Settings → Advanced Security is still the outstanding item; the API path is blocked by the agent proxy, so it can't be done from here.

## Updates applied

GitHub Actions:

| Action | From | To | PR |
| --- | --- | --- | --- |
| `github/codeql-action` | v3 | v4 | #29 |
| `googleapis/release-please-action` | v4 | v5 | #30 |

Notebook pipeline, `requirements.txt`:

| Package | From | To | PR |
| --- | --- | --- | --- |
| `huggingface-hub` | 1.28.0 | 1.29.0 | #27 |
| `selenium` | 4.47.0 | 4.48.0 | #27 |
| `sentence-transformers` | 6.0.0 | 6.0.1 | #27 |
| `statsmodels` | 0.14.6 | 0.15.0 | #27 |
| `plotly` | 6.9.0 | 7.0.0 | #28 |

Frontend, npm:

| Package | From | To | PR |
| --- | --- | --- | --- |
| `@testing-library/user-event` | ^14.6.6 | ^14.6.7 | #31 |

Everything is included this round — nothing had to be dropped, unlike the TypeScript 7 and ESLint 10 bumps in #26.

## Two changes that needed judgement

**`release-please-action` v4 → v5** is a major, but its only breaking change is the runtime moving from node20 to node24. The `config-file` and `manifest-file` inputs are unchanged. Since the action is now natively node24, the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` shim in `release.yml` — which existed precisely to run the node20 v4 action on node24 — is now redundant, so it's removed. It was the only step in that job, so nothing else relied on it.

**`plotly` 6 → 7 and `statsmodels` 0.14 → 0.15** touch the notebook pipeline, which has no CI coverage at all — a bad pin here fails silently until someone opens a notebook. So rather than trust the pins, I resolved `requirements.txt` on Python 3.12 and imported and exercised every API the notebooks actually call:

- plotly: `go.Figure`, `go.Scatter`, `make_subplots`, `px.line`, `plotly_white` template
- statsmodels: `ARIMA` fit / `forecast` / `get_forecast().conf_int()`, `adfuller`, `acf`, `pacf`, `seasonal_decompose`, `plot_acf`, `plot_pacf`

All resolve and run unchanged under the new pins. The backend is unaffected — it pins `statsmodels>=0.14.0` through `backend/pyproject.toml` and its `uv.lock` is untouched by this PR.

**One thing to note for later:** statsmodels 0.15 emits a `FutureWarning` that `adfuller` will return an `ADFullerResult` instead of a plain tuple in 0.16 (or July 2027, whichever is later). `model_exploration.ipynb` calls `adfuller` and unpacks the tuple, so it will need `result_object=` set before that release lands. Not a problem today, and out of scope here.

## Verification

- `make lint` — ruff check + format, eslint, tsc, prettier: all pass
- `make test` — 76 backend pytest + 34 frontend vitest: all pass
- `npm run build` — production build succeeds, all 7 routes emit
- `./scripts/security-audit.sh all` — npm audit and pip-audit both clean
- YAML parse of all five workflows plus `dependabot.yml`
- notebook requirements resolved and API-smoke-tested on Python 3.12 (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RQUPFCowzqHYGPU3Qcd24

---
_Generated by [Claude Code](https://claude.ai/code/session_014RQUPFCowzqHYGPU3Qcd24)_