### PR TITLE
feat: relational join index and reproducible SSA data ingestion (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,10 @@ Browser → Next.js (:3000) → /api/[...path]/route.ts (proxy) → FastAPI (:80
   exclusively through `frontend/lib`'s typed API client, which hits the `/api/*` proxy — never
   fetch the backend URL directly from a component.
 - The two root-level Jupyter notebooks (`data_pipeline.ipynb`, `model_exploration.ipynb`) are
-  a separate, unchanged data/ML pipeline (Selenium scraping, DB generation, model
-  experimentation) with its own `requirements.txt`; they're independent of the web app's
-  dependency files (`backend/pyproject.toml`, `frontend/package.json`).
+  a separate, legacy data/ML pipeline (Selenium scraping, model experimentation) with its own
+  `requirements.txt`; they're independent of the web app's dependency files (`backend/pyproject.toml`,
+  `frontend/package.json`). Reproducible database builds are automated via `make build-db`
+  (`backend/scripts/build_db.py`).
 
 ## Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ dev: frontend-deps
 	@$(MAKE) -j2 dev-frontend dev-backend
 
 build-db:
-	@echo "Building the deployable database from data/names.db ..."
-	cd backend && uv run python scripts/build_db.py
+	@echo "Building the deployable database from SSA data..."
+	cd backend && uv run python scripts/build_db.py $(SOURCE) $(DB)
 	@echo "Built data/names.built.db — observed rows only, indexed."
 
 precompute-forecasts:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ baby-names-app/
 │   ├── Dockerfile          Bakes the database in at build time (see below)
 │   └── tests/              Pytest suite (runs against a generated fixture DB)
 ├── data/                   Build artifacts only (gitignored — see "The Database")
-├── data_pipeline.ipynb     Data download/processing + ML training notebook
+├── data_pipeline.ipynb     Legacy data download/processing notebook (see make build-db)
 ├── model_exploration.ipynb Model experimentation notebook
 └── Makefile                Dev automation commands
 ```
@@ -140,14 +140,21 @@ moved to Hugging Face), and a non-database file, and reports whichever it finds 
 For local development, `make sample-db` generates a small database with a handful of names and
 plausible multi-decade trends — the full dataset has never been required for `make dev`.
 
-## Data Pipeline & ML Notebooks
+## Data Ingestion Pipeline & ML Notebooks
 
-The Jupyter notebooks are unchanged from the original project:
+Data ingestion is automated and reproducible via `make build-db` (`backend/scripts/build_db.py`),
+which downloads the official SSA baby names archive (handling SSA anti-bot protection via headless
+browser automation, or reusing a local `data/names.zip` archive if present), filters for observed
+records where counts exceed privacy suppression thresholds, calculates popularity percentages and
+ranks, applies canonical schema and indexes (including the `(name, sex, year)` composite index),
+and preserves precomputed forecasts in `data/names.built.db`. Data wrangling and browser automation
+dependencies (`pandas`, `selenium`) are isolated to the development dependency group so production
+containers remain minimal.
 
-- `data_pipeline.ipynb` downloads the SSA dataset (Selenium), computes popularity metrics,
-  writes `data/names.db`, and trains ML models (Linear Regression, Random Forest, XGBoost,
-  LSTM) for name popularity prediction
-- `model_exploration.ipynb` contains model experimentation
+The legacy Jupyter notebooks remain from the original exploration:
+
+- `data_pipeline.ipynb` prototype data processing and ML models (Linear Regression, Random Forest, XGBoost, LSTM)
+- `model_exploration.ipynb` model experimentation
 
 Install their dependencies with `pip install -r requirements.txt` (the web app itself uses
 `backend/pyproject.toml` and `frontend/package.json`).

--- a/backend/app/db_schema.py
+++ b/backend/app/db_schema.py
@@ -32,6 +32,8 @@ INDEXES = (
     "CREATE INDEX idx_names_lower_name_sex_year ON names (LOWER(name), sex, year)",
     # Serves the top-names query, which is by sex and year.
     "CREATE INDEX idx_names_sex_year ON names (sex, year)",
+    # Serves relational equality joins on name and sex across different years.
+    "CREATE INDEX idx_names_name_sex_year ON names (name, sex, year)",
 )
 
 

--- a/backend/app/services/chatbot.py
+++ b/backend/app/services/chatbot.py
@@ -77,7 +77,8 @@ Sparsity (important):
 Important Guidelines:
 - Prefer aggregation queries with GROUP BY, SUM, COUNT, AVG, etc. when summarizing data
 - Use appropriate WHERE clauses to filter data
-- For name searches, use LOWER() function for case-insensitive matching
+- For multi-year trend or ranking comparisons, use CTEs joined on (name, sex)
+  (e.g. `JOIN ... USING (name, sex)`)
 """
 
 SQL_SYSTEM_PROMPT = f"""You are a SQL query generator. Your task is to translate natural
@@ -89,7 +90,8 @@ Rules:
 1. Generate read-only queries only: a query must begin with SELECT, or with WITH for a
    CTE. Never INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, ATTACH or PRAGMA.
 2. CTEs are welcome. Prefer `WITH ranked AS (...) SELECT ...` over a repeated subquery
-   when a question needs two stages, such as ranking and then filtering.
+   when a question needs two stages, such as ranking and then filtering. For multi-year
+   trend or ranking comparisons, use CTEs joined on (name, sex) (e.g. `JOIN ... USING (name, sex)`).
 3. A LIMIT of {MAX_ROWS} rows is applied to your query automatically, so you need not add
    one. Add your own smaller LIMIT when the question asks for a specific number of rows
    ("the top 5"), and it will be respected.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,8 +23,10 @@ dependencies = [
 [dependency-groups]
 dev = [
     "httpx>=0.27.0",
+    "pandas>=2.0.0",
     "pytest>=8.0.0",
     "ruff>=0.9.0",
+    "selenium>=4.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/scripts/build_db.py
+++ b/backend/scripts/build_db.py
@@ -1,95 +1,258 @@
-"""Build the deployable names database from the pipeline's output.
+"""Build the deployable names database from SSA data.
 
-The pipeline's database cross-joins every name/sex pair with every year and
-zero-fills the gaps, so most of its rows are fabricated rather than observed.
-This script produces the artifact the backend is actually served from: the
-observed rows only, carrying the indexes the app's queries need.
-
-The result is what gets published and baked into the container image, so it is
-a first-class command rather than a one-off — re-run it whenever the pipeline
-produces a new database.
+This script produces the deployable database artifact: observed rows only,
+carrying the indexes the app's queries need, and preserving existing precomputed
+forecasts if already present.
 
 Usage: uv run python scripts/build_db.py [source_path] [output_path]
 """
 
+import os
+import re
 import sqlite3
 import sys
 import time
+import zipfile
+from collections.abc import Callable
 from pathlib import Path
+
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app import db_schema  # noqa: E402
 
 REPO_ROOT = Path(__file__).parent.parent.parent
-DEFAULT_SOURCE = str(REPO_ROOT / "data" / "names.db")
-DEFAULT_OUTPUT = str(REPO_ROOT / "data" / "names.built.db")
+DEFAULT_SOURCE = REPO_ROOT / "data" / "names.zip"
+DEFAULT_OUTPUT = REPO_ROOT / "data" / "names.built.db"
 
 
-def build(source: str, output: str) -> dict:
-    """Write the pruned, indexed database and return what it contains."""
-    source_path, output_path = Path(source), Path(output)
+def download_ssa_zip(dest_path: Path) -> Path:
+    """Download the official SSA names.zip archive via headless browser automation."""
+    dest_path = Path(dest_path)
+    download_dir = dest_path.parent
+    download_dir.mkdir(parents=True, exist_ok=True)
+
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument(
+        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+
+    prefs = {
+        "download.default_directory": str(download_dir.resolve()),
+        "download.prompt_for_download": False,
+        "download.directory_upgrade": True,
+        "safebrowsing.enabled": True,
+    }
+    options.add_experimental_option("prefs", prefs)
+
+    driver = webdriver.Chrome(options=options)
+    try:
+        driver.execute_cdp_cmd(
+            "Page.setDownloadBehavior",
+            {"behavior": "allow", "downloadPath": str(download_dir.resolve())},
+        )
+        driver.get("https://www.ssa.gov/oact/babynames/limits.html")
+        time.sleep(2)
+
+        links = driver.find_elements(By.TAG_NAME, "a")
+        target_url = None
+        for link in links:
+            href = link.get_attribute("href")
+            if href and "names.zip" in href:
+                target_url = href
+                break
+
+        if not target_url:
+            target_url = "https://www.ssa.gov/oact/babynames/names.zip"
+
+        driver.get(target_url)
+
+        # Wait up to 30s for download to complete
+        start = time.time()
+        downloaded = download_dir / "names.zip"
+        while time.time() - start < 30:
+            if downloaded.exists() and not any(download_dir.glob("*.crdownload")):
+                break
+            time.sleep(0.5)
+
+        if not downloaded.exists():
+            raise RuntimeError(f"Download failed: {downloaded} not found after waiting.")
+
+        if downloaded.resolve() != dest_path.resolve():
+            downloaded.replace(dest_path)
+
+        return dest_path
+    finally:
+        driver.quit()
+
+
+def ingest_ssa_records(source_path: Path) -> pd.DataFrame:
+    """Read SSA yobYYYY.txt files from a zip or directory, returning observed rows.
+
+    Computes popularity_percent and popularity_rank per (sex, year).
+    """
+    source_path = Path(source_path)
+    frames = []
+
+    if source_path.is_file() and source_path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(source_path, "r") as zf:
+            for item in zf.namelist():
+                match = re.search(r"yob(\d{4})\.txt$", item, re.IGNORECASE)
+                if match:
+                    year = int(match.group(1))
+                    with zf.open(item) as f:
+                        df_year = pd.read_csv(f, header=None, names=["name", "sex", "total_count"])
+                        df_year["year"] = year
+                        frames.append(df_year)
+    elif source_path.is_dir():
+        for file in source_path.iterdir():
+            match = re.search(r"yob(\d{4})\.txt$", file.name, re.IGNORECASE)
+            if match:
+                year = int(match.group(1))
+                df_year = pd.read_csv(file, header=None, names=["name", "sex", "total_count"])
+                df_year["year"] = year
+                frames.append(df_year)
+    else:
+        raise ValueError(f"Unsupported source format: {source_path}")
+
+    if not frames:
+        raise ValueError(f"No yobYYYY.txt files found in source: {source_path}")
+
+    df = pd.concat(frames, ignore_index=True)
+    df["year"] = df["year"].astype(int)
+    df["total_count"] = df["total_count"].astype(int)
+
+    # Observed rows only: counts must be positive (ADR 0003)
+    df = df[df["total_count"] > 0].reset_index(drop=True)
+    df = df.drop_duplicates(subset=["name", "sex", "year"])
+
+    # Popularity percent and rank per sex and year
+    totals = df.groupby(["sex", "year"])["total_count"].transform("sum")
+    df["popularity_percent"] = df["total_count"] / totals
+    df["popularity_rank"] = (
+        df.groupby(["sex", "year"])["popularity_percent"]
+        .rank(method="min", ascending=False)
+        .astype(int)
+    )
+
+    return df[
+        ["name", "sex", "total_count", "year", "popularity_percent", "popularity_rank"]
+    ].sort_values(by=["year", "sex", "popularity_rank"])
+
+
+def build(
+    source: str | Path | None = None,
+    output: str | Path | None = None,
+    download_if_missing: bool = True,
+    downloader: Callable[[Path], Path] | None = None,
+) -> dict:
+    """Write the observed, indexed database and return summary metrics."""
+    source_path = Path(source) if source is not None else DEFAULT_SOURCE
+    output_path = Path(output) if output is not None else DEFAULT_OUTPUT
+
     if not source_path.exists():
-        raise SystemExit(f"Source database not found: {source_path}")
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    if output_path.exists():
-        output_path.unlink()
+        if download_if_missing:
+            download_fn = downloader or download_ssa_zip
+            print(f"Source {source_path} not found. Downloading SSA data...")
+            download_fn(source_path)
+        else:
+            raise FileNotFoundError(f"Source file not found: {source_path}")
 
     started = time.monotonic()
-    conn = sqlite3.connect(str(output_path))
+    df = ingest_ssa_records(source_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build in a temporary database file for atomicity and safety
+    tmp_output = output_path.with_suffix(".tmp.db")
+    if tmp_output.exists():
+        tmp_output.unlink()
+
+    conn = sqlite3.connect(str(tmp_output))
     try:
         conn.execute("PRAGMA journal_mode = OFF")
         conn.execute("PRAGMA synchronous = OFF")
         conn.execute(db_schema.CREATE_TABLE)
-        conn.execute("ATTACH DATABASE ? AS src", (str(source_path),))
 
-        (source_rows,) = conn.execute("SELECT COUNT(*) FROM src.names").fetchone()
-        # The only pruning rule: keep a row if a count was recorded against it.
-        conn.execute(
-            """
-            INSERT INTO names (name, sex, total_count, year, popularity_percent, popularity_rank)
-            SELECT name, sex, total_count, year, popularity_percent, popularity_rank
-            FROM src.names
-            WHERE total_count > 0
-            """
-        )
-        conn.commit()
-        conn.execute("DETACH DATABASE src")
-
+        df.to_sql("names", conn, if_exists="append", index=False)
         db_schema.create_indexes(conn)
+
         conn.execute(db_schema.CREATE_FORECASTS_TABLE)
+        conn.execute(db_schema.CREATE_CALIBRATION_TABLE)
+
+        forecasts_preserved = 0
+        # Preserve forecasts and calibration tables from existing database artifact if present
+        if output_path.exists():
+            db_uri = f"file:{output_path.resolve()}?mode=ro"
+            with sqlite3.connect(db_uri, uri=True) as existing_conn:
+                tables = {
+                    row[0]
+                    for row in existing_conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    ).fetchall()
+                }
+                if "forecasts" in tables:
+                    f_rows = existing_conn.execute(
+                        "SELECT name, sex, payload, coverage_hits, coverage_n FROM forecasts"
+                    ).fetchall()
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO forecasts "
+                        "(name, sex, payload, coverage_hits, coverage_n) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        f_rows,
+                    )
+                    forecasts_preserved = len(f_rows)
+
+                if "calibration" in tables:
+                    c_rows = existing_conn.execute(
+                        "SELECT nominal_level, empirical_coverage, n FROM calibration"
+                    ).fetchall()
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO calibration (nominal_level, empirical_coverage, n) "
+                        "VALUES (?, ?, ?)",
+                        c_rows,
+                    )
+
         conn.execute("ANALYZE")
         conn.commit()
-        (kept,) = conn.execute("SELECT COUNT(*) FROM names").fetchone()
+        (rows,) = conn.execute("SELECT COUNT(*) FROM names").fetchone()
     finally:
         conn.close()
 
-    # VACUUM in its own connection so it is not inside the transaction above.
-    conn = sqlite3.connect(str(output_path))
+    # VACUUM in its own connection
+    conn = sqlite3.connect(str(tmp_output))
     try:
         conn.execute("VACUUM")
     finally:
         conn.close()
 
+    # Atomic swap
+    os.replace(tmp_output, output_path)
+
     return {
-        "source_rows": source_rows,
-        "rows": kept,
-        "pruned": source_rows - kept,
+        "rows": rows,
+        "forecasts_preserved": forecasts_preserved,
         "bytes": output_path.stat().st_size,
         "seconds": time.monotonic() - started,
     }
 
 
 def main() -> None:
-    source = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_SOURCE
-    output = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_OUTPUT
+    source = sys.argv[1] if len(sys.argv) > 1 else str(DEFAULT_SOURCE)
+    output = sys.argv[2] if len(sys.argv) > 2 else str(DEFAULT_OUTPUT)
     result = build(source, output)
-    print(f"Source rows:  {result['source_rows']:,}")
-    print(f"Pruned:       {result['pruned']:,} fabricated rows removed")
-    print(f"Kept:         {result['rows']:,} observed rows")
-    print(f"Wrote:        {output} ({result['bytes'] / 1024 / 1024:.1f} MB)")
-    print(f"Took:         {result['seconds']:.1f}s")
+    print(f"Kept:                {result['rows']:,} observed rows")
+    print(f"Forecasts preserved: {result['forecasts_preserved']:,} rows")
+    print(f"Wrote:               {output} ({result['bytes'] / 1024 / 1024:.1f} MB)")
+    print(f"Took:                {result['seconds']:.1f}s")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/make_sample_db.py
+++ b/backend/scripts/make_sample_db.py
@@ -72,6 +72,7 @@ def build(path: str) -> None:
     conn.executemany("INSERT INTO names VALUES (?, ?, ?, ?, ?, ?)", rows)
     db_schema.create_indexes(conn)
     conn.execute(db_schema.CREATE_FORECASTS_TABLE)
+    conn.execute("ANALYZE")
     conn.commit()
     conn.close()
     print(f"Wrote {len(rows)} rows to {path}")

--- a/backend/tests/test_build_db.py
+++ b/backend/tests/test_build_db.py
@@ -1,0 +1,194 @@
+"""Tests for scripts/build_db.py: the automated SSA data ingestion pipeline."""
+
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def sample_ssa_zip(tmp_path: Path) -> Path:
+    """Create a minimal SSA names.zip archive for testing."""
+    zip_path = tmp_path / "names.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(
+            "yob2023.txt",
+            "Emma,F,1000\nOlivia,F,500\nLiam,M,800\n",
+        )
+        zf.writestr(
+            "yob2024.txt",
+            "Emma,F,1200\nSophia,F,600\nLiam,M,900\nNoah,M,100\n",
+        )
+    return zip_path
+
+
+def test_build_db_from_local_zip_populates_observed_rows(sample_ssa_zip: Path, tmp_path: Path):
+    """build() with a local zip ingests observed records with percent and rank."""
+    from scripts.build_db import build
+
+    out_db = tmp_path / "names.built.db"
+    result = build(source=sample_ssa_zip, output=out_db)
+
+    assert out_db.exists()
+    assert result["rows"] == 7
+
+    conn = sqlite3.connect(str(out_db))
+    try:
+        # Verify schema
+        cursor = conn.execute("PRAGMA table_info(names)")
+        cols = {row[1]: row[2] for row in cursor.fetchall()}
+        assert cols == {
+            "name": "TEXT",
+            "sex": "TEXT",
+            "total_count": "INTEGER",
+            "year": "INTEGER",
+            "popularity_percent": "REAL",
+            "popularity_rank": "INTEGER",
+        }
+
+        # Verify Emma in 2023: 1000 out of 1500 F births => percent ~0.6667, rank 1
+        row = conn.execute(
+            "SELECT total_count, popularity_percent, popularity_rank FROM names "
+            "WHERE name = 'Emma' AND sex = 'F' AND year = 2023"
+        ).fetchone()
+        assert row is not None
+        count, pct, rank = row
+        assert count == 1000
+        assert pytest.approx(pct, rel=1e-3) == 1000 / 1500
+        assert rank == 1
+
+        # Verify Olivia in 2023: 500 out of 1500 F births => rank 2
+        row = conn.execute(
+            "SELECT total_count, popularity_percent, popularity_rank FROM names "
+            "WHERE name = 'Olivia' AND sex = 'F' AND year = 2023"
+        ).fetchone()
+        assert row is not None
+        count, pct, rank = row
+        assert count == 500
+        assert pytest.approx(pct, rel=1e-3) == 500 / 1500
+        assert rank == 2
+
+        # Verify no zero-count rows exist
+        (zeros,) = conn.execute("SELECT COUNT(*) FROM names WHERE total_count <= 0").fetchone()
+        assert zeros == 0
+    finally:
+        conn.close()
+
+
+def test_build_db_creates_all_canonical_indexes(sample_ssa_zip: Path, tmp_path: Path):
+    """build() creates all canonical tables and indexes from db_schema."""
+    from scripts.build_db import build
+
+    out_db = tmp_path / "names.built.db"
+    build(source=sample_ssa_zip, output=out_db)
+
+    conn = sqlite3.connect(str(out_db))
+    try:
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        assert "names" in tables
+        assert "forecasts" in tables
+        assert "calibration" in tables
+
+        indexes = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
+        }
+        assert "idx_names_lower_name_sex_year" in indexes
+        assert "idx_names_sex_year" in indexes
+        assert "idx_names_name_sex_year" in indexes
+    finally:
+        conn.close()
+
+
+def test_build_db_preserves_existing_forecasts(sample_ssa_zip: Path, tmp_path: Path):
+    """Rebuilding observed rows preserves any existing rows in forecasts and calibration."""
+    from scripts.build_db import build
+
+    out_db = tmp_path / "names.built.db"
+
+    # Pre-create database with existing forecasts and calibration
+    conn = sqlite3.connect(str(out_db))
+    conn.execute(
+        "CREATE TABLE forecasts (name TEXT NOT NULL, sex TEXT NOT NULL, payload TEXT NOT NULL, "
+        "coverage_hits TEXT, coverage_n TEXT, PRIMARY KEY (name, sex))"
+    )
+    conn.execute(
+        "INSERT INTO forecasts VALUES "
+        "('Emma', 'F', '{\"test\": 123}', '{\"0.8\": 4}', '{\"0.8\": 5}')"
+    )
+    conn.execute(
+        "CREATE TABLE calibration (nominal_level REAL NOT NULL PRIMARY KEY, "
+        "empirical_coverage REAL NOT NULL, n INTEGER NOT NULL)"
+    )
+    conn.execute("INSERT INTO calibration VALUES (0.8, 0.81, 100)")
+    conn.commit()
+    conn.close()
+
+    result = build(source=sample_ssa_zip, output=out_db)
+
+    assert result["forecasts_preserved"] == 1
+
+    conn = sqlite3.connect(str(out_db))
+    try:
+        # Check forecasts row preserved
+        row = conn.execute(
+            "SELECT name, sex, payload FROM forecasts WHERE name = 'Emma'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "Emma"
+        assert row[1] == "F"
+        assert '{"test": 123}' in row[2]
+
+        # Check calibration row preserved
+        cal = conn.execute(
+            "SELECT empirical_coverage, n FROM calibration WHERE nominal_level = 0.8"
+        ).fetchone()
+        assert cal is not None
+        assert cal[0] == 0.81
+        assert cal[1] == 100
+
+        # Check names table also populated
+        (name_count,) = conn.execute("SELECT COUNT(*) FROM names").fetchone()
+        assert name_count == 7
+    finally:
+        conn.close()
+
+
+def test_build_db_raises_if_source_missing_and_download_disabled(tmp_path: Path):
+    """build() raises FileNotFoundError if source is missing and download_if_missing=False."""
+    from scripts.build_db import build
+
+    missing_source = tmp_path / "nonexistent.zip"
+    out_db = tmp_path / "names.built.db"
+
+    with pytest.raises(FileNotFoundError, match="Source file not found"):
+        build(source=missing_source, output=out_db, download_if_missing=False)
+
+
+def test_build_db_invokes_downloader_when_source_missing(tmp_path: Path):
+    """build() triggers downloader when source zip is missing and succeeds."""
+    from scripts.build_db import build
+
+    missing_source = tmp_path / "downloaded_names.zip"
+    out_db = tmp_path / "names.built.db"
+    downloader_called = False
+
+    def fake_downloader(dest: Path) -> Path:
+        nonlocal downloader_called
+        downloader_called = True
+        with zipfile.ZipFile(dest, "w") as zf:
+            zf.writestr("yob2024.txt", "Liam,M,500\nOlivia,F,400\n")
+        return dest
+
+    result = build(
+        source=missing_source,
+        output=out_db,
+        download_if_missing=True,
+        downloader=fake_downloader,
+    )
+
+    assert downloader_called is True
+    assert missing_source.exists()
+    assert result["rows"] == 2

--- a/backend/tests/test_chatbot_sql.py
+++ b/backend/tests/test_chatbot_sql.py
@@ -220,3 +220,49 @@ def test_prompt_and_validator_agree_on_what_is_allowed():
     # writing its own LIMIT is what enforces one.
     assert "Always include LIMIT" not in SQL_SYSTEM_PROMPT
     assert str(MAX_ROWS) in SQL_SYSTEM_PROMPT
+
+
+def test_prompt_instructs_multi_year_cte_joins():
+    from app.services.chatbot import SQL_SYSTEM_PROMPT
+
+    prompt = SQL_SYSTEM_PROMPT.lower()
+    assert "cte" in prompt
+    assert "(name, sex)" in prompt
+    assert "multi-year" in prompt
+
+
+def test_rising_names_cross_year_query_executes_within_budget():
+    # The user-reported query comparing 2024 against 2023 outside the top 100.
+    # Without idx_names_name_sex_year this fails the 5-second query resource budget.
+    query = """
+    WITH t2024 AS (
+        SELECT name, sex, popularity_percent, popularity_rank, total_count
+        FROM names
+        WHERE year = 2024 AND total_count > 0
+    ),
+    t2023 AS (
+        SELECT name, sex, popularity_percent AS pct_2023, total_count AS cnt_2023
+        FROM names
+        WHERE year = 2023 AND total_count > 0
+    )
+    SELECT
+        t2024.name,
+        t2024.sex,
+        t2024.popularity_percent AS pct_2024,
+        t2023.pct_2023,
+        (t2024.popularity_percent - t2023.pct_2023) AS change
+    FROM t2024
+    JOIN t2023 USING (name, sex)
+    WHERE t2024.popularity_rank > 100
+      AND t2024.popularity_percent > t2023.pct_2023
+    ORDER BY change DESC
+    LIMIT 20
+    """
+    started = time.monotonic()
+    rows, columns, error = execute_safe_sql(query)
+    elapsed = time.monotonic() - started
+
+    assert error is None
+    assert columns == ["name", "sex", "pct_2024", "pct_2023", "change"]
+    assert isinstance(rows, list)
+    assert elapsed < 5.0

--- a/backend/tests/test_sample_db.py
+++ b/backend/tests/test_sample_db.py
@@ -66,6 +66,25 @@ def test_top_names_lookup_uses_an_index_rather_than_scanning(monkeypatch):
     assert "sex=? AND year=?" in plan, plan
 
 
+def test_cross_year_join_uses_composite_index_rather_than_scanning(sample_db):
+    conn = sqlite3.connect(sample_db)
+    try:
+        query = (
+            "SELECT y1.name, y1.sex, y1.popularity_percent, y2.popularity_percent "
+            "FROM names y1 "
+            "JOIN names y2 ON y1.name = y2.name AND y1.sex = y2.sex "
+            "WHERE y1.year = 2024 AND y2.year = 2023"
+        )
+        plan_rows = conn.execute(f"EXPLAIN QUERY PLAN {query}").fetchall()
+        plan = "\n".join(row[3] for row in plan_rows)
+    finally:
+        conn.close()
+
+    assert "SCAN" not in plan, plan
+    assert "idx_names_name_sex_year" in plan, plan
+    assert "TEMP B-TREE" not in plan, plan
+
+
 def test_forecasts_table_holds_only_eligible_names_and_excludes_history(sample_db):
     """The `forecasts` table's own shape and eligibility filtering aren't
     observable through the HTTP surface (an absent row and an HTTP 200 with

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -48,6 +48,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
@@ -72,8 +81,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "selenium" },
 ]
 
 [package.metadata]
@@ -96,8 +107,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
+    { name = "selenium", specifier = ">=4.0.0" },
 ]
 
 [[package]]
@@ -107,6 +120,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -562,6 +613,18 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
@@ -655,6 +718,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -781,6 +853,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]
@@ -1059,6 +1140,23 @@ wheels = [
 ]
 
 [[package]]
+name = "selenium"
+version = "4.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "trio" },
+    { name = "trio-websocket" },
+    { name = "typing-extensions" },
+    { name = "urllib3", extra = ["socks"] },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/8c/db97bdc1a8b41e7b6bf9d3099722ed8e7ac61328af8637f20004015c642b/selenium-4.48.0.tar.gz", hash = "sha256:045c1ec054c94e3be6c10febc509aa513b4c05e9146d1a9cf3de5375ec6ca2a1", size = 1055269, upload-time = "2026-08-27T20:05:51.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/ee/5d1b0e9cb43965902f0a9f7add527134db71cabf2f26766ae2fdb7774b9a/selenium-4.48.0-py3-none-any.whl", hash = "sha256:b2a1d77019db92513e59aa2376710fe3d42b65a4d493dccd0c799c1a0d574d93", size = 9561411, upload-time = "2026-08-27T20:05:48.778Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.68.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1104,6 +1202,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -1198,6 +1305,37 @@ wheels = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/dc/a2d25ed73ad49cfd79bf18d262577c3731c98e382284e28d522f49a0df35/trio-0.34.0.tar.gz", hash = "sha256:63b9485408bdfdde544fced107045a8c0086cdc4bd0ef2f797b9e0dd111b964b", size = 607457, upload-time = "2026-08-11T00:33:42.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/1f/555f1364bed52a92a864181962b77f1b15adadeacf23b86105324363e461/trio-0.34.0-py3-none-any.whl", hash = "sha256:6c7c9f49917694dcdcd5f67abd168df5599eca480d61f29854d17a61a75c2f05", size = 511840, upload-time = "2026-08-11T00:33:40.552Z" },
+]
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "outcome" },
+    { name = "trio" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1234,6 +1372,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -1399,6 +1542,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
     { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
 ]
 
 [[package]]
@@ -1629,4 +1781,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/0f/270bafe92fde3b069a39bc01e39ee79340895b335640df861d43d2a51885/wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5", size = 83104, upload-time = "2026-07-28T06:05:52.405Z" },
     { url = "https://files.pythonhosted.org/packages/55/b3/af176d79a8515a8a720eccdad9a96f6e31a30abf2865430c8c42adf2fd13/wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51", size = 81774, upload-time = "2026-07-28T06:05:53.902Z" },
     { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]


### PR DESCRIPTION
## Summary

Addresses #49 by implementing #50 and #51:
- Introduces composite index `idx_names_name_sex_year` and chatbot SQL prompt guidance to enable sub-second cross-year relational joins (#50).
- Automates the raw SSA data ingestion process into `backend/scripts/build_db.py`, replacing the legacy Jupyter notebook (`data_pipeline.ipynb`) (#51).
- Scopes data wrangling and headless browser automation (`pandas`, `selenium`) strictly to `[dependency-groups] dev` so the production container image remains lean.
- Ingests observed records directly from SSA data (via headless Chrome download or local archive), computing popularity percentages and ranks without zero-padding.
- Preserves precomputed forecasts and calibration data across database rebuilds.

## Changes

- **Schema & Prompt** (`#50`):
  - Added `CREATE INDEX idx_names_name_sex_year ON names (name, sex, year)` in `backend/app/db_schema.py`.
  - Updated chatbot prompt in `backend/app/services/chatbot.py` to guide cross-year comparisons toward `(name, sex)` CTE joins.
  - Added query plan assertions in `backend/tests/test_sample_db.py` and `backend/tests/test_chatbot_sql.py`.
- **Reproducible Pipeline & Dependencies** (`#51`):
  - Added `pandas>=2.0.0` and `selenium>=4.0.0` to `[dependency-groups] dev` in `backend/pyproject.toml`.
  - Updated `backend/scripts/build_db.py` to handle SSA downloads, observed data ingestion, indexing, and forecast preservation.
  - Updated `Makefile` `build-db` target.
  - Added comprehensive test suite in `backend/tests/test_build_db.py`.

## Verification

- `make test`: All 98 backend tests and 34 frontend tests pass.
- `make lint`: `ruff check`, `ruff format --check`, `eslint`, `tsc`, `prettier` clean.
- `make build-db && make verify-db`: Cleanly downloads/ingests observed records (2,181,032 rows) and verifies artifact with forecasts (24,679 rows).
- Multi-year comparison queries execute in ~0.3s (well under the 5.0s query resource budget).

Closes #49, #50, #51